### PR TITLE
Syntax Error Line 351

### DIFF
--- a/src/Modules/xADSyncPSConnectorModule.psm1
+++ b/src/Modules/xADSyncPSConnectorModule.psm1
@@ -348,8 +348,7 @@ function New-GenericObject
       $ConstructorParameters
     )
 
-    $genericTypeName = $typeName + '
- `r`n' + $typeParameters.Count
+    $genericTypeName = $typeName + '`' + $typeParameters.Count
     $genericType = [Type]$genericTypeName
 
     if (!$genericType)


### PR DESCRIPTION
Errors on Export to CSV, before change:
Cannot convert the "System.Collections.Generic.List'
 `r`n' value of type "System.String" to type "System.Type".
At C:\Program Files\Microsoft Forefront Identity Manager\2010\Synchronization Service\MaData\O365 License 
Import\xADSyncPSConnectorModule.psm1:355 char:5
-     $genericType = [Type]$genericTypeName
-     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  - CategoryInfo          : InvalidArgument: (:) [], RuntimeException
  - FullyQualifiedErrorId : InvalidCastFromStringToType

After change the object was properly resolved as System.Collections.Generic.List'1 :
IsPublic IsSerial Name                                     BaseType                                                     

---

True     True     List`1                                   System.Object
